### PR TITLE
opa: Improve the download logic

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -700,12 +700,20 @@ EOF
 			#   	OPA should be built from the cached source code instead of downloading
 			#   	this binary.
 			#
+			local opa_repo_url="$(get_package_version_from_kata_yaml externals.open-policy-agent.url)"
+			local opa_version="$(get_package_version_from_kata_yaml externals.open-policy-agent.version)"
 			if [ "$ARCH" == "ppc64le" ] || [ "$ARCH" == "s390x" ]; then
-				opa_repo_url="$(get_package_version_from_kata_yaml externals.open-policy-agent.url)"
 				info "Building OPA binary from source at ${opa_repo_url}"
 				build_opa_from_source "${opa_repo_url}" || die "Failed to build OPA"
 			else
-				opa_bin_url="$(get_package_version_from_kata_yaml externals.open-policy-agent.meta.binary)"
+				local opa_binary_arch
+				case ${ARCH} in
+					x86_64) opa_binary_arch="amd64" ;;
+					aarch64) opa_binary_arch="arm64" ;;
+					*) die "Unsupported architecture for the OPA binary" ;;
+				esac
+
+				local opa_bin_url="${opa_repo_url}/releases/download/${opa_version}/opa_linux_${opa_binary_arch}_static"
 				info "Downloading OPA binary from ${opa_bin_url}"
 				curl --fail -L "${opa_bin_url}" -o opa || die "Failed to download OPA"
 			fi

--- a/versions.yaml
+++ b/versions.yaml
@@ -297,17 +297,6 @@ externals:
     description: "Open Policy Agent"
     url: "https://github.com/open-policy-agent/opa"
     version: "v0.55.0"
-    meta:
-      # - If an OPA package is available for the Guest image distro, that
-      #   package is used instead of the binary below.
-      #
-      # - TODO: if an OPA package is not available for the Guest image distro,
-      #   Kata should cache the OPA source code, toolchain information, etc.
-      #   OPA should be built from the cached source code instead of downloading
-      #   this binary.
-      #
-      # yamllint disable-line rule:line-length
-      binary: "https://github.com/open-policy-agent/opa/releases/download/v0.55.0/opa_linux_amd64_static"
 
   ovmf:
     description: "Firmware, implementation of UEFI for virtual machines."


### PR DESCRIPTION
The versions.yaml has a default for the amd64 binary, but there is no code to actually build the arm64 binary, which seems an overlook.

Let's simplify the OPA logic by removing the direct link to the binary, and construct that link as part of the checks we do to decide whether we need to build OPA or not.

Fixes: #8373